### PR TITLE
bug fix in chatinputarea

### DIFF
--- a/auto-analyst-frontend/components/chat/ChatInputArea.tsx
+++ b/auto-analyst-frontend/components/chat/ChatInputArea.tsx
@@ -10,7 +10,10 @@ const ChatInputArea = () => {
   const { data: session } = useSession()
   const { hasFreeTrial } = useFreeTrialStore()
   const { isLoading, handleSendMessage, handleFileUpload, handleStopGeneration } = useChatState()
-  const chatInputRef = useRef<{ handlePreviewDefaultDataset: () => void }>(null)
+  const chatInputRef = useRef<{ 
+    handlePreviewDefaultDataset: () => void; 
+    handleSilentDefaultDataset: () => void; 
+  }>(null)
   const isAdmin = localStorage.getItem('isAdmin') === 'true'
   
   const isInputDisabled = () => {


### PR DESCRIPTION
This pull request includes a small change to the `auto-analyst-frontend/components/chat/ChatInputArea.tsx` file. The change updates the `chatInputRef` to include a new method for handling silent default datasets.

* [`auto-analyst-frontend/components/chat/ChatInputArea.tsx`](diffhunk://#diff-5f1e0a0350ba75cab0456061d7c00077592765f49bea6b088c3e9d99a749de4dL13-R16): Added `handleSilentDefaultDataset` method to the `chatInputRef` object.