### PR TITLE
Tool tip added for non signed in users

### DIFF
--- a/auto-analyst-frontend/app/chat/page.tsx
+++ b/auto-analyst-frontend/app/chat/page.tsx
@@ -1,10 +1,26 @@
 "use client"
 
+import { useEffect } from "react"
 import ChatInterface from "@/components/chat/ChatInterface"
 import ResponsiveLayout from "../../components/ResponsiveLayout"
 import "../globals.css"
+import { useFreeTrialStore } from "@/lib/store/freeTrialStore"
+import { useSession } from "next-auth/react"
 
 export default function ChatPage() {
+  const { status } = useSession()
+  const { queriesUsed, hasFreeTrial } = useFreeTrialStore()
+  
+  // Check for first-time free trial users
+  useEffect(() => {
+    if (status === "unauthenticated" && queriesUsed === 0 && hasFreeTrial()) {
+      // First-time free trial user, set flag to show onboarding tooltip
+      if (!localStorage.getItem('hasSeenOnboarding')) {
+        localStorage.setItem('showOnboarding', 'true')
+      }
+    }
+  }, [status, queriesUsed, hasFreeTrial])
+  
   return (
     <ResponsiveLayout>
       <ChatInterface />


### PR DESCRIPTION
This pull request introduces changes to enhance the onboarding experience for free trial users by adding logic to display onboarding tooltips under specific conditions. The changes primarily focus on detecting first-time free trial users and ensuring they are guided appropriately. Below are the most important changes grouped by theme:

### Onboarding Logic for Free Trial Users:
* Added a `useEffect` in `ChatPage` (`auto-analyst-frontend/app/chat/page.tsx`) to check if the user is unauthenticated, has not used any queries, and is eligible for a free trial. If these conditions are met, a flag is set in `localStorage` to show the onboarding tooltip.
* Updated the onboarding logic in `ChatInterface` (`auto-analyst-frontend/components/chat/ChatInterface.tsx`) to ensure the tooltip is shown for both signed-in users and free trial users. The tooltip is triggered based on a `localStorage` flag and includes a delay for better UI readiness. [[1]](diffhunk://#diff-40779bdb05425a17fac6c5eceeb9dce743a9d173c4596f769db9befc20064253L117-R119) [[2]](diffhunk://#diff-40779bdb05425a17fac6c5eceeb9dce743a9d173c4596f769db9befc20064253R129-R142)

### First Query Onboarding for Free Trial Users:
* Added logic in `ChatInterface` to set a flag in `localStorage` when a free trial user sends their first query and has not seen the onboarding tooltip. This flag ensures the onboarding tooltip is displayed after the first query is processed.
* Enhanced the message processing flow in `ChatInterface` to check for the first query onboarding flag after a message is processed. If the flag is present, the onboarding tooltip is displayed, and the flag is updated to prevent repeated onboarding.