### PR TITLE
Enhance useTemplates Hook for SSR Compatibility in Custom Templates Component

### DIFF
--- a/auto-analyst-frontend/components/chat/Sidebar.tsx
+++ b/auto-analyst-frontend/components/chat/Sidebar.tsx
@@ -88,7 +88,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, onNewChat, chatHisto
   // Also check admin status on client side only
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setIsAdmin(localStorage.getItem('isAdmin') === 'true')
+    setIsAdmin(localStorage.getItem('isAdmin') === 'true')
     }
   }, [])
   

--- a/auto-analyst-frontend/components/custom-templates/useTemplates.ts
+++ b/auto-analyst-frontend/components/custom-templates/useTemplates.ts
@@ -86,7 +86,9 @@ export function useTemplates({ userId, enabled = true }: UseTemplatesProps): Use
         ))
         
         // Dispatch event for other components
-        window.dispatchEvent(new CustomEvent('template-preferences-updated'))
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('template-preferences-updated'))
+        }
         
         return true
       } else {
@@ -123,7 +125,9 @@ export function useTemplates({ userId, enabled = true }: UseTemplatesProps): Use
         }))
 
         // Dispatch event for other components
-        window.dispatchEvent(new CustomEvent('template-preferences-updated'))
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('template-preferences-updated'))
+        }
 
         const successful = result.results?.filter((r: any) => r.success).length || updates.length
         const failed = result.results?.filter((r: any) => !r.success).length || 0
@@ -159,6 +163,8 @@ export function useTemplates({ userId, enabled = true }: UseTemplatesProps): Use
 
   // Listen for external updates
   useEffect(() => {
+    if (typeof window === 'undefined') return
+
     const handleUpdate = () => {
       loadData()
     }


### PR DESCRIPTION
This pull request introduces improvements to the `useTemplates` function in `auto-analyst-frontend/components/custom-templates/useTemplates.ts` to ensure compatibility with server-side rendering (SSR). The changes primarily involve adding checks for the `window` object to prevent errors when running in non-browser environments.

Enhancements for SSR compatibility:

* Added a check to verify `typeof window !== 'undefined'` before dispatching the `template-preferences-updated` event, ensuring the code doesn't break in SSR environments. [[1]](diffhunk://#diff-0e4d36e6976a0b8c4b3294561d91bdb40cf030fcf71e152a7914a989fbb6bde1R89-R91) [[2]](diffhunk://#diff-0e4d36e6976a0b8c4b3294561d91bdb40cf030fcf71e152a7914a989fbb6bde1R128-R130)
* Added a check to verify `typeof window === 'undefined'` before setting up the `useEffect` listener for external updates, preventing unnecessary operations during SSR.