### PR TITLE
Add Billing Cycle Toggle to Checkout Page for Improved Plan Selection UX

### DIFF
--- a/auto-analyst-frontend/app/api/user/cancel-subscription/route.ts
+++ b/auto-analyst-frontend/app/api/user/cancel-subscription/route.ts
@@ -48,11 +48,11 @@ export async function POST(request: NextRequest) {
       
       // Only make Stripe API calls for new users with proper subscription IDs
       if (!isLegacyUser) {
-        // Cancel the subscription in Stripe
-        // Using cancel_at_period_end: true to let the user keep access until the end of their current billing period
+      // Cancel the subscription in Stripe
+      // Using cancel_at_period_end: true to let the user keep access until the end of their current billing period
         canceledSubscription = await stripe.subscriptions.update(stripeSubscriptionId, {
-          cancel_at_period_end: true,
-        })
+        cancel_at_period_end: true,
+      })
         console.log(`Scheduled Stripe cancellation for subscription ${stripeSubscriptionId} for user ${userId}`)
       } else {
         console.log(`Legacy user ${userId} - skipping Stripe API calls, updating Redis only`)
@@ -85,10 +85,10 @@ export async function POST(request: NextRequest) {
         if (creditData && creditData.resetDate) {
           await redis.hset(KEYS.USER_CREDITS(userId), {
             nextTotalCredits: '0', // No credits after cancellation
-            pendingDowngrade: 'true',
+          pendingDowngrade: 'true',
             lastUpdate: now.toISOString()
-          })
-        }
+        })
+      }
       }
       
       return NextResponse.json({

--- a/auto-analyst-frontend/lib/credits-config.ts
+++ b/auto-analyst-frontend/lib/credits-config.ts
@@ -49,9 +49,9 @@ export interface TrialConfig {
  * Trial period configuration - Change here to update across the entire app
  */
 export const TRIAL_CONFIG: TrialConfig = {
-  duration: 10,
+  duration: 5,
   unit: 'minutes',
-  displayText: '10-Minute Trial',
+  displayText: '5-Minute Trial',
   credits: 500
 }
 


### PR DESCRIPTION

This PR improves the checkout experience by allowing users to toggle between **monthly** and **yearly** billing cycles directly on the checkout page. It removes the need to return to the pricing page to switch plans and provides clear, real-time feedback on pricing and savings.

---

### 🔧 Key Features

* **📅 Billing Cycle Toggle**
  Users can switch between monthly and yearly plans during checkout.

* **💸 Real-Time Pricing Updates**
  Updates setup intent and pricing dynamically on toggle.

* **💰 Savings Visualization**
  Displays yearly discount breakdown and monthly equivalent pricing.

* **🎨 Enhanced UX**
  Loading indicators and disabled states during plan updates for smooth interaction.

---

### 👨‍💻 Technical Summary

* Added `billingCycle` state to manage toggle logic.
* Updated checkout flow to dynamically fetch correct price IDs and recalculate totals.
* Improved `Order Summary` to reflect accurate totals, discounts, and billing info.
* Cleaned up props in `CheckoutForm` and removed unnecessary bindings.

---

### ✅ Result

* Users can now **easily compare and switch** between billing cycles at checkout.
* Promotes **transparency and trust** through clear pricing breakdowns.
* Encourages **yearly plan adoption** by highlighting savings.
