### PR TITLE
Update Trial Duration to 2 Days Across App

### DIFF
--- a/auto-analyst-frontend/app/checkout/page.tsx
+++ b/auto-analyst-frontend/app/checkout/page.tsx
@@ -531,9 +531,9 @@ export default function CheckoutPage() {
                     )}
                     
                     <div className="mt-3 pt-2 border-t border-gray-100">
-                      <p className="text-sm text-gray-500">
-                        Billed {planDetails.cycle === 'year' ? 'yearly' : planDetails.cycle === 'day' ? 'daily' : 'monthly'}
-                      </p>
+                    <p className="text-sm text-gray-500">
+                      Billed {planDetails.cycle === 'year' ? 'yearly' : planDetails.cycle === 'day' ? 'daily' : 'monthly'}
+                    </p>
                       {billingCycle === 'yearly' && (
                         <p className="text-xs text-gray-400 mt-1">
                           Credits reset monthly, but you're billed yearly
@@ -581,9 +581,9 @@ export default function CheckoutPage() {
                               )}
                               {discountApplied && discountInfo && (
                                 `You save $${
-                                  discountInfo.type === 'percent' 
-                                    ? ((planDetails.amount * discountInfo.value) / 100).toFixed(2)
-                                    : discountInfo.value.toFixed(2)
+                              discountInfo.type === 'percent' 
+                                ? ((planDetails.amount * discountInfo.value) / 100).toFixed(2)
+                                : discountInfo.value.toFixed(2)
                                 } with promo code!`
                               )}
                               {billingCycle === 'yearly' && planDetails.name === 'Standard' && discountApplied && discountInfo && (

--- a/auto-analyst-frontend/app/pricing/page.tsx
+++ b/auto-analyst-frontend/app/pricing/page.tsx
@@ -32,7 +32,7 @@ const pricingTiers = [
       'Advanced data analysis',
       'Access to all models',
       'Priority support',
-      `${TrialUtils.getTrialDisplayText()} free trial`,
+      `${TrialUtils.getTrialDisplayText()}`,
     ],
     highlight: true,
     trial: true,

--- a/auto-analyst-frontend/lib/credits-config.ts
+++ b/auto-analyst-frontend/lib/credits-config.ts
@@ -49,9 +49,9 @@ export interface TrialConfig {
  * Trial period configuration - Change here to update across the entire app
  */
 export const TRIAL_CONFIG: TrialConfig = {
-  duration: 5,
-  unit: 'minutes',
-  displayText: '5-Minute Trial',
+  duration: 2,
+  unit: 'days',
+  displayText: '2-Day Trial',
   credits: 500
 }
 

--- a/auto-analyst-frontend/lib/credits-config.ts
+++ b/auto-analyst-frontend/lib/credits-config.ts
@@ -51,7 +51,7 @@ export interface TrialConfig {
 export const TRIAL_CONFIG: TrialConfig = {
   duration: 2,
   unit: 'days',
-  displayText: '2-Day',
+  displayText: '2-Day Free Trial',
   credits: 500
 }
 

--- a/auto-analyst-frontend/lib/credits-config.ts
+++ b/auto-analyst-frontend/lib/credits-config.ts
@@ -51,7 +51,7 @@ export interface TrialConfig {
 export const TRIAL_CONFIG: TrialConfig = {
   duration: 2,
   unit: 'days',
-  displayText: '2-Day Trial',
+  displayText: '2-Day',
   credits: 500
 }
 


### PR DESCRIPTION
This PR updates the trial duration to **2 days** and adjusts related display text accordingly.

* Trial config updated to reflect `2-Day Free Trial`
* Pricing page logic simplified by embedding "Free Trial" in the display text directly

No changes to credit amount (remains 500).
