### PR TITLE
Fix Trial End Behavior for Stripe API v2025-05-28

### DIFF
--- a/auto-analyst-frontend/app/api/trial/start/route.ts
+++ b/auto-analyst-frontend/app/api/trial/start/route.ts
@@ -98,8 +98,14 @@ export async function POST(request: NextRequest) {
       trial_end: trialEndTimestamp,
       expand: ['latest_invoice.payment_intent'],
       payment_behavior: 'default_incomplete',
+      default_payment_method: setupIntent.payment_method as string,
       payment_settings: {
         save_default_payment_method: 'on_subscription',
+      },
+      trial_settings: {
+        end_behavior: {
+          missing_payment_method: 'cancel'
+        }
       },
       metadata: {
         userId: userId || 'anonymous',

--- a/auto-analyst-frontend/lib/credits-config.ts
+++ b/auto-analyst-frontend/lib/credits-config.ts
@@ -49,9 +49,9 @@ export interface TrialConfig {
  * Trial period configuration - Change here to update across the entire app
  */
 export const TRIAL_CONFIG: TrialConfig = {
-  duration: 2,
+  duration: 15,
   unit: 'minutes',
-  displayText: '2-Minute Free Trial',
+  displayText: '15-Minute Free Trial',
   credits: 500
 }
 


### PR DESCRIPTION
Fixes unintended draft invoice creation after trial ends by updating `trial_settings.end_behavior` to `'cancel'` and setting `default_payment_method` from `setupIntent`, ensuring immediate payment attempt post-trial and preventing zombie subscriptions.


TODO: Change Credit Config to be 2-Day Free Trial after Test.